### PR TITLE
Add theme name to zip filename

### DIFF
--- a/generate_all.php
+++ b/generate_all.php
@@ -418,7 +418,7 @@
   if (Zip($folder, $zipname)) {
   	header('Set-Cookie: fileDownload=true'); 
   	header("Content-type: application/zip" );
-  	header('Content-Disposition: attachment; filename="android-holo-colors.zip"');
+  	header('Content-Disposition: attachment; filename="android-holo-colors-'.$name.'.zip"');
 	header('Content-Length: ' . filesize($zipname));
 	header("Expires: 0");
 	header("Cache-Control: no-cache, must-revalidate");


### PR DESCRIPTION
Theme name should be added to the zip filename to avoid clashes if you download more than one theme.

Also matches what (most) of the other asset studio tools do.
