### PR TITLE
Fixes mistype "iten" -> "item"

### DIFF
--- a/widgets/edittext/res/drawable/edit_text_holo_dark.xml
+++ b/widgets/edittext/res/drawable/edit_text_holo_dark.xml
@@ -18,7 +18,7 @@
     <item android:state_window_focused="false" android:state_enabled="true" android:drawable="@drawable/textfield_default_holo_dark" />
     <item android:state_window_focused="false" android:state_enabled="false" android:drawable="@drawable/textfield_disabled_holo_dark" />
     <item android:state_enabled="true" android:state_focused="true" android:drawable="@drawable/textfield_activated_holo_dark" />
-    <iten android:state_enabled="true" android:state_activated="true" android:drawable="@drawable/textfield_focused_holo_dark" />
+    <item android:state_enabled="true" android:state_activated="true" android:drawable="@drawable/textfield_focused_holo_dark" />
     <item android:state_enabled="true" android:drawable="@drawable/textfield_default_holo_dark" />
     <item android:state_focused="true" android:drawable="@drawable/textfield_disabled_focused_holo_dark" />
     <item android:drawable="@drawable/textfield_disabled_holo_dark" />


### PR DESCRIPTION
Noticed this for light theme, thought I would check dark theme as well, looks like it also had this bug.
