### PR TITLE
Missing "android:" before color/transparent reference

### DIFF
--- a/widgets/list/res/drawable/item_background_holo_light.xml
+++ b/widgets/list/res/drawable/item_background_holo_light.xml
@@ -22,5 +22,5 @@
     <item android:state_focused="true"                                android:state_pressed="true" android:drawable="@drawable/list_selector_background_transition_holo_light" />
     <item android:state_focused="false"                               android:state_pressed="true" android:drawable="@drawable/list_selector_background_transition_holo_light" />
     <item android:state_focused="true"                                                             android:drawable="@drawable/list_focused_holo" />
-    <item                                                                                          android:drawable="@color/transparent" />
+    <item                                                                                          android:drawable="@android:color/transparent" />
 </selector>


### PR DESCRIPTION
Fixing this bug issue: https://github.com/jeromevdl/android-holo-colors/issues/41
